### PR TITLE
Fwd sim

### DIFF
--- a/GeneticInheritanceGraphLibrary/graph.py
+++ b/GeneticInheritanceGraphLibrary/graph.py
@@ -75,6 +75,7 @@ class Graph:
                 )
 
         # check all parents are strictly older than their children
+        # (NB: this also allows a time of np.inf for an "ultimate root" node)
         node_times = self.tables.nodes.time
         for i, ie in enumerate(self.iedges):
             if node_times[ie.parent] <= node_times[ie.child]:
@@ -342,15 +343,15 @@ class Graph:
         Returns a dict of dicts of the following form
             {
                 MRCA_node_ID1 : {(X, Y): (
-                    {(uA, uB), (uC, uD), ...},
-                    {(vA, vB), ...}
+                    [(uA, uB), (uC, uD), ...],
+                    [(vA, vB), ...]
                 )},
                 MRCA_node_ID2 : ...,
                 ...
             }
         Where in each inner dict, the key (X, Y) gives an interval (with X < Y)
         in the MRCA node, and the value is a 2-tuple giving the corresponding
-        intervals in u and v. In the example above there is a set of two
+        intervals in u and v. In the example above there is a list of two
         corresponding intervals in u: (uA, uB) and (uC, uD) representing a
         duplication of the MRCA interval into u. If uA > uB then that interval
         in u is inverted relative to that in the MRCA node.
@@ -369,7 +370,7 @@ class Graph:
         4. We do not add older regions to the stack if they have coalesced.
         5. We have a time cutoff, so that we don't have to go all the way
            back to the "origin of life"
-        6. We have to keep track of the offset (delta) of the current interval into the
+        6. We have to keep track of the offset of the current interval into the
            original genome, to allow mapping back to the original coordinates
         """
         if not isinstance(u, (int, np.integer)) or not isinstance(v, (int, np.integer)):
@@ -389,7 +390,7 @@ class Graph:
         # therefore store a *dictionary* of portion objects, keyed by offset and
         # orientation.
         #
-        # We store *two* such {(delta, orientation): intervals} dicts. The first
+        # We store *two* such {(offset, orientation): intervals} dicts. The first
         # tracks the ancestral regions of u, and the second the ancestral regions of v.
         # If a node has something in both dicts, intervals for u and v co-occur
         # (and could therefore coalesce), meaning the node is a potential MRCA.
@@ -440,15 +441,15 @@ class Graph:
                     # Work out the mapping of the mrca intervals into intervals in
                     # u and v, given keys into the uv_intervals dicts.
                     for mrca, uv_details in result[child].items():
-                        to_store = (set(), set())  # is a set too slow?
-                        for store, details in zip(to_store, uv_details):
+                        to_store = ([], [])
+                        for s, details in zip(to_store, uv_details):
                             # Odd that we don't use the interval dict here: not sure why
                             for key, _ in details:
-                                delta, inverted_relative_to_original = key
+                                offset, inverted_relative_to_original = key
                                 if inverted_relative_to_original:
-                                    store.add((delta - mrca.lower, delta - mrca.upper))
+                                    s.append((offset - mrca.lower, offset - mrca.upper))
                                 else:
-                                    store.add((mrca.lower - delta, mrca.upper - delta))
+                                    s.append((mrca.lower - offset, mrca.upper - offset))
                         result[child][mrca] = to_store  # replace
 
                     # Remove the coalesced segments from the interval lists
@@ -465,20 +466,20 @@ class Graph:
                 child_ivl = P.closedopen(ie.child_left, ie.child_right)  # cache
                 is_inversion = ie.is_inversion()
                 for u_or_v, interval_dict in enumerate((u_dict, v_dict)):
-                    for (delta, already_inverted), intervals in interval_dict.items():
+                    for (offset, already_inverted), intervals in interval_dict.items():
                         for interval in intervals:
                             if c := child_ivl & interval:
                                 p = ie.transform_interval((c.lower, c.upper), ROOTWARDS)
                                 if is_inversion:
                                     if already_inverted:
                                         # 0 gets flipped backwards
-                                        x = delta - (c.lower + p[0])
+                                        x = offset - (c.lower + p[0])
                                     else:
-                                        x = delta + (c.lower + p[0])
+                                        x = offset + (c.lower + p[0])
                                     already_inverted = not already_inverted
                                     parent_ivl = P.closedopen(p[1], p[0])
                                 else:
-                                    x = delta - c.lower + p[0]
+                                    x = offset - c.lower + p[0]
                                     parent_ivl = P.closedopen(*p)
                                 key = (x, already_inverted)
                                 if parent not in stack:

--- a/GeneticInheritanceGraphLibrary/graph.py
+++ b/GeneticInheritanceGraphLibrary/graph.py
@@ -514,8 +514,6 @@ class Graph:
         tot_len = sum(x[1] - x[0] for v in mrcas_structure.values() for x in v.keys())
         # Pick a single breakpoint
         loc = rng.integers(tot_len)  # breakpoint is before this base
-        print("tot_len:", tot_len, "chosen loc:", loc)
-        print(mrcas_structure)
         for mrca_intervals in mrcas_structure.values():
             for x in mrca_intervals.keys():
                 if loc < x[1] - x[0]:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ The easiest example is an inversion. This would be an iedge like
 {parent: P, child: C, child_left: 100, child_right: 200, parent_left: 200, parent_right: 100}
 ```
 
+There is a subtle gotcha here, because intervals in a GIG, as in _tskit_, are treated as half-closed
+(i.e. do not include the position given by the right coordinate). When we invert an interval, it
+therefore does not include the *left* parent coordinate, but does include the *right* parent coordinate.
+Any transformed position is thus out by one. Or to put it another way, an inversion specified
+by child_left=0, child_right=3, parent_left=3, parent_right=0 transforms the points
+0, 1, 2 to 2, 1, 0 - although the *interval* 0, 3 is transformed to 0, 3., the *point* 0 is transformed
+to position 2, not position 3. See
+[here](https://github.com/hyanwong/GeneticInheritanceGraphLibrary/issues/41#issuecomment-1858530867)
+for more discussion.
+
 ### Duplications
 
 A tandem duplication is represented by two iedges, one for each duplicated region:

--- a/tests/test_gigutil.py
+++ b/tests/test_gigutil.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from .gigutil import DTWF_no_recombination_sim
+from .gigutil import DTWF_one_recombination_no_SV_slow_sim
 
 # Tests for functions in tests/gigutil.py
 
@@ -11,3 +12,14 @@ def test_no_recomb_sim():
     gig = simulator.run(num_diploids=10, seq_len=100, generations=gens, random_seed=1)
     assert len(np.unique(gig.tables.nodes.time)) == gens + 1
     assert gig.num_iedges > 0
+
+
+def test_one_recomb_sim():
+    gens = 10
+    simulator = DTWF_one_recombination_no_SV_slow_sim()
+    gig = simulator.run(num_diploids=10, seq_len=100, generations=gens, random_seed=1)
+    assert len(np.unique(gig.tables.nodes.time)) == gens + 1
+    assert gig.num_iedges > 0
+    print(gig.tables)
+    ts = gig.to_tree_sequence()
+    assert ts.num_samples == len(gig.samples)

--- a/tests/test_gigutil.py
+++ b/tests/test_gigutil.py
@@ -20,7 +20,6 @@ def test_one_recomb_sim():
     gig = simulator.run(num_diploids=10, seq_len=100, generations=gens, random_seed=1)
     assert len(np.unique(gig.tables.nodes.time)) == gens + 1
     assert gig.num_iedges > 0
-    print(gig.tables)
     ts = gig.to_tree_sequence()
     assert ts.num_samples == len(gig.samples)
     assert ts.num_trees > 1

--- a/tests/test_gigutil.py
+++ b/tests/test_gigutil.py
@@ -23,3 +23,5 @@ def test_one_recomb_sim():
     print(gig.tables)
     ts = gig.to_tree_sequence()
     assert ts.num_samples == len(gig.samples)
+    assert ts.num_trees > 1
+    assert ts.at_index(0).num_edges > 0

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -623,16 +623,18 @@ class TestFindMrcas:
         assert set(mrca[(160, 200)][0]) == {(160, 200), (260, 300)}
         assert mrca[(160, 200)][1] == [(160, 200)]
 
-    def test_find_mrca_breakpoints(self, inverted_duplicate_gig):
-        np.random.seed(1)
-        assert inverted_duplicate_gig.num_samples == 2
-        mrcas = inverted_duplicate_gig.find_mrca_regions(0, 1)
-        assert len(mrcas) == 1
-        # pick the number of breakpoints (no interference between breakpoints here:
-        # we can have 2 breakpoints arbitrarily close together, although we could
-        # probably implement interference via rejection sampling.
-
-        # here we could assume that a breakpoint between regions of interted orientation
-        # leads to nonviable gametes
-
-        # Return a
+    def test_random_matching_positions(self, simple_ts):
+        rng = np.random.default_rng(1)
+        ts = simple_ts.keep_intervals([(0, 2)]).trim()
+        gig = gigl.from_tree_sequence(ts)
+        assert gig.samples[0] == 0
+        assert gig.samples[1] == 1
+        mrcas = gig.find_mrca_regions(0, 1)
+        all_breaks = set()
+        for _ in range(20):
+            # in 20 replicates we should definitely have both 0 and 1
+            breaks = gig.random_matching_positions(mrcas, rng)
+            assert len(breaks) == 2
+            assert breaks[0] == breaks[1]
+            all_breaks.add(breaks[0])
+        assert all_breaks == {0, 1}

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -514,8 +514,8 @@ class TestFindMrcas:
         mrca = mrcas[3]
         assert (0, 100) in mrca
         u, v = mrca[(0, 100)]
-        assert u == {(0, 100)}
-        assert v == {(0, 100)}
+        assert u == [(0, 100)]
+        assert v == [(0, 100)]
 
     @pytest.mark.parametrize("sample_resolve", [True, False])
     def test_extended_inversion(self, extended_inversion_gig, sample_resolve):
@@ -545,13 +545,13 @@ class TestFindMrcas:
         mrca = mrcas[3]
         assert (10, 15) in mrca  # the duplicated+inverted section
         u, v = mrca[(10, 15)]
-        assert u == {(0, 5), (15, 10)}
-        assert v == {(0, 5)}
+        assert set(u) == {(0, 5), (15, 10)}
+        assert v == [(0, 5)]
 
         assert (15, 20) in mrca  # only the inverted section
         u, v = mrca[(15, 20)]
-        assert u == {(10, 5)}
-        assert v == {(5, 10)}
+        assert u == [(10, 5)]
+        assert v == [(5, 10)]
 
     def test_inverted_duplicate_with_missing(self, inverted_duplicate_with_missing_gig):
         assert inverted_duplicate_with_missing_gig.num_samples == 2
@@ -561,13 +561,13 @@ class TestFindMrcas:
         mrca = mrcas[3]
         assert (10, 15) in mrca  # the duplicated+inverted section
         u, v = mrca[(10, 15)]
-        assert u == {(0, 5), (35, 30)}
-        assert v == {(0, 5)}
+        assert set(u) == {(0, 5), (35, 30)}
+        assert v == [(0, 5)]
 
         assert (15, 20) in mrca  # only the inverted section
         u, v = mrca[(15, 20)]
-        assert u == {(30, 25)}
-        assert v == {(5, 10)}
+        assert u == [(30, 25)]
+        assert v == [(5, 10)]
 
     def test_no_recomb_sv_dup_del(self, all_sv_types_gig):
         assert all_sv_types_gig.num_samples >= 2
@@ -607,16 +607,32 @@ class TestFindMrcas:
         mrca = mrcas[12]
         # "normal" region
         assert (0, 80) in mrca
-        assert mrca[(0, 80)] == ({(0, 80)}, {(0, 80)})
+        assert mrca[(0, 80)] == ([(0, 80)], [(0, 80)])
 
         # start of inverted region
         assert (80, 100) in mrca
-        assert mrca[(80, 100)] == ({(80, 100)}, {(160, 140)})
+        assert mrca[(80, 100)] == ([(80, 100)], [(160, 140)])
 
         # duplicated inverted region
         assert (100, 160) in mrca
-        assert mrca[(100, 160)] == ({(100, 160), (200, 260)}, {(140, 80)})
+        assert set(mrca[(100, 160)][0]) == {(100, 160), (200, 260)}
+        assert mrca[(100, 160)][1] == [(140, 80)]
 
         # duplicated non-inverted region
         assert (160, 200) in mrca
-        assert mrca[(160, 200)] == ({(160, 200), (260, 300)}, {(160, 200)})
+        assert set(mrca[(160, 200)][0]) == {(160, 200), (260, 300)}
+        assert mrca[(160, 200)][1] == [(160, 200)]
+
+    def test_find_mrca_breakpoints(self, inverted_duplicate_gig):
+        np.random.seed(1)
+        assert inverted_duplicate_gig.num_samples == 2
+        mrcas = inverted_duplicate_gig.find_mrca_regions(0, 1)
+        assert len(mrcas) == 1
+        # pick the number of breakpoints (no interference between breakpoints here:
+        # we can have 2 breakpoints arbitrarily close together, although we could
+        # probably implement interference via rejection sampling.
+
+        # here we could assume that a breakpoint between regions of interted orientation
+        # leads to nonviable gametes
+
+        # Return a


### PR DESCRIPTION
Creates a simple forward simulator with recombination (`DTWF_one_recombination_no_SV_slow_sim ` in gigutils.py)

There are no structural variations being created in here yet, but recombination seems to work, hurrah!

Logic is not fully tested yet. One way to do this would be to create an equivalent tree sequence forward simulator using the same RNG calls, and check the outputs are the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for selecting random matching positions within MRCA regions in the Genetic Inheritance Graph Library.
- **Enhancements**
	- Updated several methods to improve accuracy by using lists instead of sets for interval handling.
	- Enhanced the Genetic Inheritance Graph Library with additional utility functions and logic for simulating genetic inheritance with recombination and without structural variants.
- **Documentation**
	- Updated the README to clarify interval inversion handling in the Genetic Inheritance Graph Library.
- **Tests**
	- Updated existing tests to align with changes in interval handling and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->