### PR TITLE
Allow variable population sizes & run_more continuation

### DIFF
--- a/GeneticInheritanceGraphLibrary/graph.py
+++ b/GeneticInheritanceGraphLibrary/graph.py
@@ -164,6 +164,11 @@ class Graph:
         return self.tables.time_units
 
     @property
+    def max_time(self):
+        # Should also incorporate mutation times here
+        return self.tables.nodes.time.max()
+
+    @property
     def num_nodes(self):
         # Deprecated
         return len(self.tables.nodes)
@@ -273,6 +278,14 @@ class Graph:
         )
         tables.sort()
         return tables.tree_sequence()
+
+    def decapitate(self, time):
+        """
+        Return a new GIG with all nodes older than time removed.
+        """
+        tables = self.tables.copy()  # placeholder for making these editable
+        tables.decapitate(time)
+        return self.__class__(tables)
 
     def sample_resolve(self):
         """
@@ -510,6 +523,9 @@ class Graph:
         adjacent, so if this is used to locate a breakpoint, the choice of
         whether a breakpoint is positioned to the left or right of the returned
         position is left to the user.
+
+        The ``rng`` parameter is intended to be a numpy random number generator with a
+        method ``integers()`` that behaves like ``np.random.default_rng().integers``.
         """
         tot_len = sum(x[1] - x[0] for v in mrcas_structure.values() for x in v.keys())
         # Pick a single breakpoint

--- a/GeneticInheritanceGraphLibrary/tables.py
+++ b/GeneticInheritanceGraphLibrary/tables.py
@@ -343,6 +343,13 @@ class Tables:
             return False
         return True
 
+    def clear(self):
+        """
+        Clear all tables
+        """
+        for name in self.table_classes.keys():
+            getattr(self, name).clear()
+
     def copy(self):
         """
         Return a deep copy of the tables
@@ -402,6 +409,22 @@ class Tables:
         if len(self.nodes) == 0:
             return np.array([], dtype=np.int32)
         return np.where(self.nodes.flags & NODE_IS_SAMPLE)[0]
+
+    def change_times(self, timedelta):
+        """
+        Add a value to all times (nodes and mutations)
+        """
+        # TODO: urrently node rows are frozen, so we can't change them in-place
+        # We should make them more easily editable.
+        node_table = NodeTable()
+        for node in self.nodes:
+            node_table.add_row(
+                time=node.time + timedelta,
+                flags=node.flags,
+                individual=node.individual,
+            )
+        self.nodes = node_table
+        # TODO - same for mutations, when we implement them
 
     @classmethod
     def from_tree_sequence(cls, ts, *, chromosome=None, timedelta=0, **kwargs):

--- a/tests/test_gigutil.py
+++ b/tests/test_gigutil.py
@@ -1,3 +1,4 @@
+import GeneticInheritanceGraphLibrary as gigl
 import numpy as np
 import pytest
 import tskit
@@ -126,15 +127,33 @@ class TestSimpleSims:
     def test_no_recomb_sim(self):
         gens = 10
         simulator = DTWF_no_recombination_sim()
-        gig = simulator.run(
-            num_diploids=10, seq_len=100, generations=gens, random_seed=1
-        )
+        gig = simulator.run(num_diploids=10, seq_len=100, gens=gens, random_seed=1)
         assert len(np.unique(gig.tables.nodes.time)) == gens + 1
         assert gig.num_iedges > 0
 
+    def test_variable_population_size(self):
+        gens = 2
+        simulator = DTWF_no_recombination_sim()
+        gig = simulator.run(
+            num_diploids=(2, 10, 20), seq_len=100, gens=gens, random_seed=1
+        )
+        times, counts = np.unique(gig.tables.nodes.time, return_counts=True)
+        assert np.array_equal(times, [0, 1, 2])
+        assert np.array_equal(counts, [40, 20, 4])
+        assert len(gig.individuals) == 2 + 10 + 20
 
-class TestDTWF_recombination_no_SV_sims:
-    def test_one_break_slow_sim(self):
+    def test_run_more(self):
+        simulator = DTWF_no_recombination_sim()
+        gens1 = 2
+        gig = simulator.run(num_diploids=2, seq_len=100, gens=gens1, random_seed=1)
+        assert len(np.unique(gig.tables.nodes.time)) == gens1 + 1
+        gens2 = 3
+        gig = simulator.run_more(num_diploids=4, seq_len=100, gens=gens2, random_seed=1)
+        assert len(np.unique(gig.tables.nodes.time)) == gens1 + gens2 + 1
+
+
+class TestDTWF_one_break_no_rec_inversions_slow:
+    def test_plain_sim(self):
         gens = 10
         simulator = DTWF_one_break_no_rec_inversions_slow_sim()
         gig = simulator.run(num_diploids=10, seq_len=100, gens=gens, random_seed=1)
@@ -145,8 +164,23 @@ class TestDTWF_recombination_no_SV_sims:
         assert ts.num_trees > 1
         assert ts.at_index(0).num_edges > 0
 
+    def test_run_more(self):
+        gens1 = 10
+        simulator = DTWF_one_break_no_rec_inversions_slow_sim()
+        gig = simulator.run(num_diploids=10, seq_len=100, gens=gens1, random_seed=1)
+        gens2 = 2
+        gig = simulator.run_more(num_diploids=(4, 2), gens=gens2, random_seed=1)
+        times, counts = np.unique(gig.tables.nodes.time, return_counts=True)
+        assert len(times) == gens1 + gens2 + 1
+        assert times[0] == 0
+        assert counts[0] == 4  # 2 * 2
+        assert times[1] == 1
+        assert counts[1] == 8  # 4 * 2
+        assert times[2] == 2
+        assert counts[2] == 20
+
     @pytest.mark.parametrize("seed", [123, 321])
-    def test_one_break_slow_sim_vs_tskit(self, seed):
+    def test_vs_tskit_implementation(self, seed):
         # The tskit_DTWF_simulator should produce identical results to the GIG simulator
         gens = 9
         L = 97
@@ -161,3 +195,53 @@ class TestDTWF_recombination_no_SV_sims:
         ts = ts.simplify(keep_unary=True, filter_individuals=False, filter_nodes=False)
         gig = gig.sample_resolve()
         ts.tables.assert_equals(gig.to_tree_sequence().tables, ignore_provenance=True)
+
+    def test_inversion(self):
+        simulator = DTWF_one_break_no_rec_inversions_slow_sim()
+        simulator.run(num_diploids=2, seq_len=1000, gens=1, random_seed=1)
+        # Insert an inversion by editing the tables
+        times, inverses = np.unique(simulator.tables.nodes.time, return_inverse=True)
+        assert len(times) == 3  # also includes the grand MRCA
+        first_gen = np.where(inverses == np.where([times == 1])[0])[0]
+        second_gen = np.where(inverses == np.where([times == 0])[0])[0]
+        assert len(first_gen) == 4  # haploid genomes
+        assert len(second_gen) == 4  # haploid genomes
+        # Edit the existing iedges to create an inversion
+        # on a single iedge
+        new_iedges = gigl.tables.IEdgeTable()
+        for ie in simulator.tables.iedges:
+            if ie.child == second_gen[0] and ie.child_left == 0:
+                assert ie.parent_left == 0
+                assert ie.child_right == ie.parent_right
+                assert ie.child_right > 200  # check seed gives breakpoint a bit along
+                new_iedges.add_row(0, 100, 0, 100, child=ie.child, parent=ie.parent)
+                new_iedges.add_row(100, 200, 200, 100, child=ie.child, parent=ie.parent)
+                new_iedges.add_row(
+                    200,
+                    ie.child_right,
+                    200,
+                    ie.parent_right,
+                    child=ie.child,
+                    parent=ie.parent,
+                )
+            else:
+                new_iedges.append(ie)
+        simulator.tables.iedges = new_iedges
+        simulator.tables.sort()
+        # Check it gives a valid gig
+        gig = simulator.tables.graph()
+        num_inversions = 0
+        for ie in gig.iedges:
+            if ie.is_inversion():
+                num_inversions += 1
+        assert num_inversions == 1
+
+        # Can progress the simulation
+        gig = simulator.run_more(num_diploids=100, gens=4, random_seed=1)
+        # check we still have an inversion in the ancestry
+        gig = gig.sample_resolve()
+        num_inversions = 0
+        for ie in gig.iedges:
+            if ie.is_inversion():
+                num_inversions += 1
+        assert num_inversions == 1

--- a/tests/test_gigutil.py
+++ b/tests/test_gigutil.py
@@ -238,10 +238,17 @@ class TestDTWF_one_break_no_rec_inversions_slow:
 
         # Can progress the simulation
         gig = simulator.run_more(num_diploids=100, gens=4, random_seed=1)
-        # check we still have an inversion in the ancestry
+        # check we still have an inversion in the ancestry: it's not been lost by drift
         gig = gig.sample_resolve()
         num_inversions = 0
         for ie in gig.iedges:
             if ie.is_inversion():
                 num_inversions += 1
         assert num_inversions == 1
+
+        # Check we can turn the decapitated gig tables into a tree sequence
+        # (because decapitation should remove the only SV)
+        new_gig = gig.decapitate(time=gig.max_time)
+        ts = new_gig.to_tree_sequence()
+        assert ts.max_time == new_gig.max_time
+        assert ts.max_time < gig.max_time

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -105,6 +105,12 @@ class TestMethods:
         assert tables.iedges[1].child == 2
         assert tables.iedges[2].child == 3
 
+    def test_change_times(self, trivial_gig):
+        tables = trivial_gig.tables
+        times = tables.nodes.time
+        tables.change_times(timedelta=1.5)
+        assert np.isclose(tables.nodes.time, times + 1.5).all()
+
 
 class TestBaseTable:
     # Test various basic table methods


### PR DESCRIPTION
Also an example of a fwd sim with an inversion (`test_inversion()` in test_gigutil.py: needs more testing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to clear all data tables for a fresh start.
	- Added functionality to modify time values for nodes, enhancing simulation accuracy.
	- Enhanced population simulation capabilities with support for variable population sizes and diploid numbers.
	- Implemented a feature to extend ongoing simulations with additional parameters for more dynamic studies.
	- Added capability to generate genetic inheritance graphs excluding the grand MRCA node for focused analyses.

- **Bug Fixes**
	- Corrected simulation logic to accurately handle population growth over generations.

- **Tests**
	- Expanded testing suite to cover new functionalities, including time modifications, population simulation extensions, and graph generation without the grand MRCA node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->