### PR TITLE
Add ability to freeze the tables

### DIFF
--- a/GeneticInheritanceGraphLibrary/graph.py
+++ b/GeneticInheritanceGraphLibrary/graph.py
@@ -40,6 +40,7 @@ class Graph:
             )
         self.tables = tables
         self._validate()
+        self.tables.freeze()
 
     def _validate(self):
         assert hasattr(self, "tables")

--- a/tests/gigutil.py
+++ b/tests/gigutil.py
@@ -227,6 +227,7 @@ class DTWF_one_break_no_rec_inversions_slow_sim(DTWF_simulator):
             except KeyError:
                 assert ie.parent == self.grand_mrca
         # Shouldn't need to sort really: we could do as a check?
+        # No need to make a copy here, as we have started with a new tables object
         return output_tables.graph()
 
     def run(self, num_diploids, seq_len, gens, *, random_seed=None):
@@ -252,7 +253,7 @@ class DTWF_one_break_no_rec_inversions_slow_sim(DTWF_simulator):
             # bugs due to e.g. not adding edges in the expected order. Therefore
             # if this call to .graph() fails, it identifies a case where an efficient
             # implementation to allow find_mrca_regions on the tables could fail.
-            self.gig = self.tables.graph()
+            self.gig = self.tables.copy().graph()
             self.new_population(gens, size=num_diploids[-gens - 1])
         return self.tables_to_gig_without_grand_mrca()
 
@@ -271,7 +272,7 @@ class DTWF_one_break_no_rec_inversions_slow_sim(DTWF_simulator):
         while gens > 0:
             gens -= 1
             # See comment above about why we currently need to run .graph() here
-            self.gig = self.tables.graph()
+            self.gig = self.tables.copy().graph()
             self.new_population(gens, size=num_diploids[-gens - 1])
         return self.tables_to_gig_without_grand_mrca()
 

--- a/tests/gigutil.py
+++ b/tests/gigutil.py
@@ -207,7 +207,7 @@ class DTWF_one_break_no_rec_inversions_slow_sim(DTWF_simulator):
         output_tables = gigl.Tables()
         output_tables.time_units = self.tables.time_units
         node_map = {}
-        for individual in self.gig.individuals:
+        for individual in self.tables.individuals:
             # No need to change the individuals: the grand MRCA has no associated
             # individuals, and the existing individuals do not reference node IDs
             output_tables.individuals.append(individual)

--- a/tests/gigutil.py
+++ b/tests/gigutil.py
@@ -138,7 +138,7 @@ class DTWF_simulator:
         self.tables.sort()
         # We should probably simplify or at least sample_resolve here?
         # Probably a parameter `simplify` would be useful?
-        return self.tables.graph()
+        return self.tables.copy().graph()
 
     def run_more(self, num_diploids, seq_len, gens, random_seed=None):
         """
@@ -159,7 +159,7 @@ class DTWF_simulator:
             self.new_population(gens, size=num_diploids[-gens - 1])
 
         self.tables.sort()
-        return self.tables.graph()
+        return self.tables.copy().graph()
 
 
 class DTWF_no_recombination_sim(DTWF_simulator):

--- a/tests/test_gigutil.py
+++ b/tests/test_gigutil.py
@@ -229,7 +229,7 @@ class TestDTWF_one_break_no_rec_inversions_slow:
         simulator.tables.iedges = new_iedges
         simulator.tables.sort()
         # Check it gives a valid gig
-        gig = simulator.tables.graph()
+        gig = simulator.tables.copy().graph()
         num_inversions = 0
         for ie in gig.iedges:
             if ie.is_inversion():


### PR DESCRIPTION
So we can ensure a GIG is immutable.

Currently failing tests, which reveal some cases where we are mutating an existing GIG (oops).

Fixes part of #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced data integrity by introducing table immutability in the Genetic Inheritance Graph Library.
- **Bug Fixes**
	- Prevented accidental data alterations by ensuring tables cannot be modified after being frozen.
- **Tests**
	- Added comprehensive tests for the new immutability feature, covering freezing, copying, and modification restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->