### PR TITLE
Debug fwd sim

### DIFF
--- a/GeneticInheritanceGraphLibrary/graph.py
+++ b/GeneticInheritanceGraphLibrary/graph.py
@@ -240,13 +240,12 @@ class Graph:
         If sequence_length is not None, it will be used as the sequence length,
         otherwise the sequence length will be the maximum position of any edge.
         """
-        if np.any(
-            self.tables.iedges.child_left != self.tables.iedges.parent_left
-        ) or np.any(self.tables.iedges.child_right != self.tables.iedges.parent_right):
-            raise ValueError(
-                "Cannot convert to tree sequence: "
-                "child and parent intervals are not the same in all iedges"
-            )
+        for ie in self.iedges:
+            if ie.child_left != ie.parent_left or ie.child_right != ie.parent_right:
+                raise ValueError(
+                    f"Cannot convert to tree sequence: iedge {ie.id}: child "
+                    f"and parent intervals are not the same in all iedges ({ie})"
+                )
         if sequence_length is None:
             sequence_length = self.tables.iedges.child_right.max()
         tables = tskit.TableCollection(sequence_length)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -680,7 +680,7 @@ class TestFindMrcas:
         assert set(mrca[(120, 200)][0]) == {(120, 200), (220, 300)}
         assert mrca[(120, 200)][1] == [(120, 200)]
 
-    def test_random_matching_positions(self, simple_ts):
+    def test_random_match_pos(self, simple_ts):
         rng = np.random.default_rng(1)
         ts = simple_ts.keep_intervals([(0, 2)]).trim()
         gig = gigl.from_tree_sequence(ts)
@@ -690,8 +690,9 @@ class TestFindMrcas:
         all_breaks = set()
         for _ in range(20):
             # in 20 replicates we should definitely have both 0 and 1
-            breaks = gig.tables.random_matching_positions(mrcas, rng)
-            assert len(breaks) == 2
-            assert breaks[0] == breaks[1]
-            all_breaks.add(breaks[0])
+            breaks = gig.tables.random_match_pos(mrcas, rng)
+            assert len(breaks) == 3
+            assert not breaks.opposite_orientations
+            assert breaks.u == breaks.v
+            all_breaks.add(breaks.u)
         assert all_breaks == {0, 1}


### PR DESCRIPTION
There's a bug in the forward simulator where we manage to produce the following edges. All edges apart from the inversion should have parent_interval == child_interval:

```
4 IEdge(child_left=0, child_right=1, parent_left=0, parent_right=1, child=170, parent=4, edge=-1, child_chromosome=-1, parent_chromosome=-1, id=332)
4 IEdge(child_left=1, child_right=122, parent_left=200, parent_right=321, child=170, parent=5, edge=-1, child_chromosome=-1, parent_chromosome=-1, id=333)
```

This PR (not yet for merging) is trying to track down the bug. In particular, since the inversion is from 100-200, we shouldn't have a recombination breakpoint at 122 unless both parents 4 and 5 share the inversion in their history

It seems suspicious that the parent_left on the bad edge is 200,  which is the right hand location of the inversion. I suspect there is some off-by-one problem in the recombination breakpoint calcs. Also these are the only two iedges with child == 170 which means that the child genome is only covered from 0..122 rather than 0..321 as it should be.