### PR TITLE
Add plot method to MRCAdict class

### DIFF
--- a/GeneticInheritanceGraphLibrary/tables.py
+++ b/GeneticInheritanceGraphLibrary/tables.py
@@ -908,6 +908,7 @@ class MRCAdict(dict):
                     U_list, V_list = mrca_intervals[X]
                     for U in U_list:
                         add_rectangle(ax, U, u_pos, "#b2df8a")
+                        x_max = max(x_max, *U)
                         if U[0] < U[1]:
                             u_0 = U[0] + highlight_position
                             add_triangle(ax, (u_0, u_0 + 1), u_pos, "right", "#33a02c")
@@ -916,6 +917,7 @@ class MRCAdict(dict):
                             add_triangle(ax, (u_0, u_0 + 1), u_pos, "left", "#33a02c")
                     for V in V_list:
                         add_rectangle(ax, V, v_pos, "#fb9a99")
+                        x_max = max(x_max, *V)
                         if V[0] < V[1]:
                             v_0 = V[0] + highlight_position
                             add_triangle(ax, (v_0, v_0 + 1), v_pos, "right", "#e31a1c")
@@ -935,11 +937,10 @@ class MRCAdict(dict):
                         fontsize,
                         color="black",
                     )
-                    U_list, V_list = mrca_intervals[X]
-                    for U in U_list:
-                        add_rectangle(ax, U, u_pos, "#838383")
-                    for V in V_list:
-                        add_rectangle(ax, V, v_pos, "#838383")
+                    for lists, pos in zip(mrca_intervals[X], (u_pos, v_pos)):
+                        for interval in lists:
+                            add_rectangle(ax, interval, pos, "#838383")
+                            x_max = max(x_max, *interval)
             y_pos += 1
 
         add_row_label(ax, x_offset, u_pos + y_offset, "U", fontsize, color="black")

--- a/GeneticInheritanceGraphLibrary/tables.py
+++ b/GeneticInheritanceGraphLibrary/tables.py
@@ -849,6 +849,7 @@ class MRCAdict(dict):
         self,
         highlight_position=None,
         ax=None,
+        *,
         fontsize=14,
         u_pos=0.5,
         v_pos=1.5,
@@ -891,19 +892,16 @@ class MRCAdict(dict):
             for X in mrca_intervals.keys():
                 x_max = max(x_max, X[1])
                 if highlight_position < X[1] - X[0] and found_breakpoint is False:
+                    # TODO - use default colours rather than hard-coding
+                    triX = X[0] + highlight_position
+                    lab = f"MRCA: {mrca_node}"
                     add_rectangle(ax, X, y_pos, "#a6cee3")
-                    add_triangle(
-                        ax,
-                        (X[0] + highlight_position, X[0] + highlight_position + 1),
-                        y_pos,
-                        "right",
-                        "#1f78b4",
-                    )
+                    add_triangle(ax, (triX, triX + 1), y_pos, "right", "#1f78b4")
                     add_row_label(
                         ax,
                         x_offset,
                         y_pos + y_offset,
-                        f"MRCA: {mrca_node}",
+                        lab,
                         fontsize,
                         color="#1f78b4",
                     )

--- a/GeneticInheritanceGraphLibrary/util.py
+++ b/GeneticInheritanceGraphLibrary/util.py
@@ -1,5 +1,7 @@
 import itertools
 
+import matplotlib.patches as patches
+
 
 def truncate_rows(num_rows, limit=None):
     """
@@ -26,3 +28,34 @@ def set_print_options(*, max_lines=40):
     from . import _print_options  # pylint: disable=import-outside-toplevel
 
     _print_options["max_lines"] = max_lines
+
+
+def add_rectangle(ax, X, y, color, height=0.8):
+    """
+    Plotting utility function for adding rectangles to MRCA plots
+    """
+    width = X[1] - X[0]
+    rect = patches.Rectangle((X[0], y), width, height, facecolor=color)
+    ax.add_patch(rect)
+
+
+def add_triangle(ax, X, y, direction, color, height=0.8):
+    """
+    Plotting utility function for adding triangles to MRCA plots
+    """
+    if direction == "right":
+        vertices = [(X[0], y), (X[0], y + height), (X[1], y + height / 2)]
+    else:
+        vertices = [(X[0], y + height / 2), (X[1], y), (X[1], y + height)]
+
+    triangle = patches.Polygon(vertices, closed=True, facecolor=color)
+    ax.add_patch(triangle)
+
+
+def add_row_label(ax, x_offset, y_pos, text, fontsize, color):
+    """
+    Plotting utility function for adding row labels to MRCA plots
+    """
+    ax.text(
+        x_offset, y_pos, text, va="center", ha="right", fontsize=fontsize, color=color
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ msprime
 numpy
 networkx
 pandas
+matplotlib

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -863,6 +863,6 @@ class TestMRCAdict:
 
     def test_gig_plot_with_size(self, all_sv_types_no_re_gig):
         mrcas = all_sv_types_no_re_gig.tables.find_mrca_regions(11, 9)
-        fig, ax = plt.subplots(1, figsize=(10, 5))
-        mrcas._plot(highlight_position=40, ax=ax)
+        fig, ax = plt.subplots(1, figsize=(15, 5))
+        mrcas._plot(highlight_position=110, ax=ax)
         # plt.savefig("test_gig_plot.png")  # uncomment to save a plot for inspection

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -5,6 +5,7 @@ import pytest
 import tskit
 from GeneticInheritanceGraphLibrary.constants import Const
 from GeneticInheritanceGraphLibrary.constants import ValidFlags
+from matplotlib import pyplot as plt
 
 
 class TestCreation:
@@ -847,3 +848,21 @@ class TestFindMrcas:
             assert breaks.u == breaks.v
             all_breaks.add(breaks.u)
         assert all_breaks == {0, 1}
+
+
+class TestMRCAdict:
+    def test_plot(self):
+        MRCAintervals = gigl.tables.MRCAdict.MRCAintervals
+        mrcas = gigl.tables.MRCAdict()
+        mrcas[0] = {
+            (0, 10): MRCAintervals([(0, 10)], [(0, 10)]),
+            (20, 30): MRCAintervals([(20, 30)], [(20, 30)]),
+        }
+        mrcas[1] = {(10, 20): MRCAintervals([(10, 20)], [(10, 20)])}
+        mrcas._plot(highlight_position=5)
+
+    def test_gig_plot_with_size(self, all_sv_types_no_re_gig):
+        mrcas = all_sv_types_no_re_gig.tables.find_mrca_regions(11, 9)
+        fig, ax = plt.subplots(1, figsize=(10, 5))
+        mrcas._plot(highlight_position=40, ax=ax)
+        # plt.savefig("test_gig_plot.png")  # uncomment to save a plot for inspection


### PR DESCRIPTION
As discussed in #79, this adds a plotting method to the new MRCAdict class which shows the MRCA intervals and corresponding sample intervals (U and V). For example:

```python
import GeneticInheritanceGraphLibrary as gigl

mrca_dict = {
    227: {(16, 18): ([(16, 18)], [(16, 18)])},
    212: {(31, 42): ([(31, 42)], [(31, 42)])},
    165: {(22, 24): ([(22, 24)], [(22, 24)])},
    148: {(10, 13): ([(10, 13)], [(10, 13)])},
    127: {(13, 16): ([(13, 16)], [(13, 16)]), (18, 22): ([(18, 22)], [(18, 22)])},
    40: {(51, 68): ([(51, 68)], [(51, 68)])},
    24: {(9, 10): ([(9, 10)], [(9, 10)])},
    7: {(68, 78): ([(68, 78)], [(68, 78)])},
    0: {
        (0, 9): ([(0, 9)], [(0, 9)]),
        (24, 31): ([(24, 31)], [(24, 31)]),
        (42, 51): ([(42, 51)], [(42, 51)]),
        (78, 100): ([(78, 100)], [(78, 100)]),
    },
}
mrca = gigl.tables.MRCAdict(mrca_dict)
mrca.plot()
```

![image](https://github.com/hyanwong/GeneticInheritanceGraphLibrary/assets/5416474/935f9dea-c591-4390-a15f-e6061f34faf3)

I've only tested it with a few simple example simulations, so it probably needs further tweaking! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a visual plotting feature for the MRCA (Most Recent Common Ancestor) data structure, including detailed node and interval visualization, with customizable parameters for enhanced analysis.
	- Added two new plotting utility functions for MRCA plots: `add_rectangle` and `add_row_label`.
	- Updated dependencies to include `matplotlib` in the `requirements.txt` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->