### PR TITLE
Allow initial sizes to be specified for the tables

### DIFF
--- a/tests/gigutil.py
+++ b/tests/gigutil.py
@@ -133,7 +133,7 @@ class DTWF_simulator:
             )
         )
 
-    def __init__(self, skip_validate=False):
+    def __init__(self, skip_validate=False, initial_sizes=None):
         """
         Create a simulation class, which can then simulate a forward Discrete Time
         Wright-Fisher model with varying population sizes over generations.
@@ -142,8 +142,11 @@ class DTWF_simulator:
         create a valid set of tables suitable for using the find_mrca_regions() method.
         Setting this to False saves a small fraction (about 2%) of the simulation time,
         at the expense of not doing any validation (dangerous!)
+
+        If initial_sizes is specified, it should be an array of the expected sizes
+        for each table, see the ``gigl.Tables.__init__`` method for more information.
         """
-        self.tables = gigl.Tables()
+        self.tables = gigl.Tables(initial_sizes=initial_sizes)
         self.tables.time_units = "generations"  # optional, but helpful when plotting
         self.skip_validate = skip_validate
 

--- a/tests/test_gigutil.py
+++ b/tests/test_gigutil.py
@@ -229,7 +229,15 @@ class TestDTWF_one_break_no_rec_inversions_slow:
             cls.test_inversion()
             print(cls.ts)
         """
-        self.simulator = sim.DTWF_one_break_no_rec_inversions_slow()
+        final_pop_size = 100
+        self.simulator = sim.DTWF_one_break_no_rec_inversions_slow(
+            initial_sizes={
+                "nodes": 2 * final_pop_size * self.default_gens,
+                "edges": 2 * final_pop_size * self.default_gens * 2,
+                "individuals": final_pop_size * self.default_gens,
+            },
+        )
+
         self.simulator.run(
             num_diploids=2,
             seq_len=self.seq_len,
@@ -309,7 +317,9 @@ class TestDTWF_one_break_no_rec_inversions_slow:
 
         # Can progress the simulation
         gig = self.simulator.run_more(
-            num_diploids=100, gens=self.default_gens - 1, random_seed=1
+            num_diploids=final_pop_size,
+            gens=self.default_gens - 1,
+            random_seed=1,
         )
         # should have deleted the grand MRCA (used for matching)
         assert len(gig.nodes) == len(self.simulator.tables.nodes) - 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to set initial sizes for tables and table collections, enhancing initialization based on specific needs.
- **Enhancements**
	- Improved table initialization in various classes to support initial size parameters, ensuring more precise control over table setups.
- **Tests**
	- Added new test methods to verify the correct handling of initial sizes in table initialization and copying processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->